### PR TITLE
4.2-v0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Spicy Particle System is a powerful and customizable particle system written in 
 https://github.com/TheRensei/godot_spicyparticlesystem/assets/32361344/80133633-27d2-4c04-aa2d-94d1a64f414e
 
 ## Documentation
-Detailed documentation will be available in the [Wiki](https://github.com/TheRensei/godot_spicyparticlesystem/wiki), providing comprehensive information on installation, usage, and customization. Check out the [getting started](https://github.com/TheRensei/godot_spicyparticlesystem/wiki/Getting-Started) section.
+Detailed documentation will be available in the [Wiki](https://github.com/TheRensei/godot_spicyparticlesystem/wiki), providing comprehensive information on installation, usage, and customization. Check out the [getting started](https://github.com/TheRensei/godot_spicyparticlesystem/wiki/0.-Getting-Started) section.
 
 ## Upcoming features
 > [!NOTE]  

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
     <img alt="Static Badge" src="https://img.shields.io/badge/Godot-4.2%2B-blue">
   </a>
   <a href="https://github.com/TheRensei/godot_spicyparticlesystem/releases/latest">
-    <img alt="GitHub release (with filter)" src="https://img.shields.io/github/v/release/TheRensei/godot_spicyparticlesystem?filter=*beta">
+    <img alt="GitHub release (with filter)" src="https://img.shields.io/github/v/release/TheRensei/godot_spicyparticlesystem?include_prereleases">
   </a>
   <a href="LICENSE">
     <img src="https://img.shields.io/github/license/TheRensei/godot_spicyparticlesystem?style=flat-square" alt="LICENSE">

--- a/src/SpicyParticleData.cpp
+++ b/src/SpicyParticleData.cpp
@@ -14,6 +14,7 @@ void godot::ParticleData::delete_data()
 	memdelete_arr(current_scale);
 	memdelete_arr(current_rotation);
 	memdelete_arr(acceleration);
+	memdelete_arr(custom_data);
 	memdelete_arr(color);
 	memdelete_arr(current_color);
 	memdelete_arr(lifetime);
@@ -46,6 +47,7 @@ void godot::ParticleData::generate(size_t max_size, const Ref<RandomNumberGenera
 	current_scale = memnew_arr(Vector3, max_size);
 	current_rotation = memnew_arr(Vector3, max_size);
 	acceleration = memnew_arr(Vector3, max_size);
+	custom_data = memnew_arr(Vector4, max_size);
 	current_color = memnew_arr(Color, max_size);
 	color = memnew_arr(Color, max_size);
 	lifetime = memnew_arr(float, max_size);
@@ -89,6 +91,7 @@ void godot::ParticleData::swap(size_t id1, size_t id2)
 	std::swap(current_scale[id1], current_scale[id2]);
 	std::swap(current_rotation[id1], current_rotation[id2]);
 	std::swap(acceleration[id1], acceleration[id2]);
+	std::swap(custom_data[id1], custom_data[id2]);
 	std::swap(color[id1], color[id2]);
 	std::swap(current_color[id1], current_color[id2]);
 	std::swap(lifetime[id1], lifetime[id2]);

--- a/src/SpicyParticleData.hpp
+++ b/src/SpicyParticleData.hpp
@@ -27,6 +27,7 @@ namespace godot
 		Vector3* current_scale;
 		Vector3* current_rotation;
 		Vector3* acceleration;
+		Vector4* custom_data;
 		Color* current_color;
 		Color* color;
 		float* lifetime;

--- a/src/SpicyParticleGenerator.cpp
+++ b/src/SpicyParticleGenerator.cpp
@@ -22,6 +22,7 @@ void godot::SpicyParticleGenerator::generate(double dt, const Ref<ParticleData> 
 		p_data->current_scale[i] = Vector3(1, 1, 1);
 		p_data->current_rotation[i] = Vector3(0, 0, 0);
 		p_data->acceleration[i] = Vector3(0, 0, 0);
+		p_data->custom_data[i] = Vector4(0, 0, 0, 0);
 		p_data->color[i] = Color(1, 1, 1, 1);
 		p_data->current_color[i] = Color(1, 1, 1, 1);
 		p_data->lifetime[i] = 0;

--- a/src/SpicyParticleRenderer.cpp
+++ b/src/SpicyParticleRenderer.cpp
@@ -188,11 +188,16 @@ void godot::MultiMeshParticleRenderer::update()
 		ptr[14] = c.b;
 		ptr[15] = c.a;
 
-		float rot = p->rotation[i].z + p->current_rotation[i].z; //that should be calculated before //optimize
-		ptr[16] = Math::deg_to_rad(rot);
-		ptr[17] = p->normalized_lifetime[i];
-		ptr[18] = ptr[17];
-		ptr[19] = 0;
+		//float rot = p->rotation[i].z + p->current_rotation[i].z; //that should be calculated before //optimize
+		//ptr[16] = Math::deg_to_rad(rot);
+		//ptr[17] = p->normalized_lifetime[i];
+		//ptr[18] = ptr[17];
+		//ptr[19] = 0;
+
+		ptr[16] = p->custom_data[i].x;
+		ptr[17] = p->custom_data[i].y;
+		ptr[18] = p->custom_data[i].z;
+		ptr[19] = p->custom_data[i].w;
 
 		ptr += mesh_data_size;
 	}

--- a/src/SpicyParticleRenderer.cpp
+++ b/src/SpicyParticleRenderer.cpp
@@ -52,13 +52,16 @@ void godot::MultiMeshParticleRenderer::apply_alignment(const Ref<ParticleData> p
 	switch (m_alignment) {
 	case ALIGNMENT_LOCAL:
 	{
-		//Should do this by default
 		return;
 	}
 	break;
 	case ALIGNMENT_WORLD:
 	{
-		out_transform.basis = p_data->particle_node->get_global_transform().affine_inverse().basis * out_transform.basis;
+		Basis world = p_data->particle_node->get_global_transform().affine_inverse().basis;
+		out_transform.basis.scale(p_data->particle_node->get_basis().get_scale());
+		out_transform.basis = world * out_transform.basis;
+
+		//out_transform.basis = p_data->particle_node->get_global_transform().affine_inverse().basis * out_transform.basis;
 	}
 	break;
 	case ALIGNMENT_SCREEN:
@@ -68,6 +71,7 @@ void godot::MultiMeshParticleRenderer::apply_alignment(const Ref<ParticleData> p
 			Basis target_basis = m_alignment_target_node->get_global_basis() * flip_xz;
 
 			out_transform.basis = target_basis * out_transform.basis;
+			out_transform.basis.scale(p_data->particle_node->get_basis().get_scale());
 			out_transform.basis = p_node_basis * out_transform.basis;
 		}
 	}
@@ -79,6 +83,7 @@ void godot::MultiMeshParticleRenderer::apply_alignment(const Ref<ParticleData> p
 			Basis p_node_basis = p_data->particle_node->get_global_transform().affine_inverse().basis;
 			Basis target_basis = p_node_basis.looking_at(m_alignment_target_node->get_global_position(), Vector3(0, 1, 0));
 
+			out_transform.basis.scale(p_data->particle_node->get_basis().get_scale());
 			out_transform.basis = target_basis * out_transform.basis;
 			out_transform.basis = p_node_basis * out_transform.basis;
 
@@ -99,11 +104,13 @@ void godot::MultiMeshParticleRenderer::apply_alignment(const Ref<ParticleData> p
 	}
 	break;
 	case ALIGNMENT_LOOK_AT:
-	{
+	{	
 		if (m_alignment_target_node != NULL) {
+
 			Basis p_node_basis = p_data->particle_node->get_global_transform().affine_inverse().basis;
 			Basis target_basis = p_node_basis.looking_at(m_alignment_target_node->get_global_position(), Vector3(0, 1, 0));
 
+			out_transform.basis.scale(p_data->particle_node->get_basis().get_scale());
 			out_transform.basis = target_basis * out_transform.basis;
 			out_transform.basis = p_node_basis * out_transform.basis;
 		}

--- a/src/SpicyParticleSystemNode.cpp
+++ b/src/SpicyParticleSystemNode.cpp
@@ -240,7 +240,7 @@ void godot::SpicyParticleSystemNode::_notification(int p_what)
 
 	case NOTIFICATION_TRANSFORM_CHANGED:
 	{
-		if (world_space)
+		if (world_space && is_inside_tree())
 			node_transform = get_global_transform();
 		else
 			node_transform = Transform3D();

--- a/src/SpicyParticleSystemNode.cpp
+++ b/src/SpicyParticleSystemNode.cpp
@@ -156,6 +156,7 @@ double frame_remainder = 0;
 
 void godot::SpicyParticleSystemNode::_internal_process(double delta)
 {
+
 	if (is_paused && !is_playing || is_stopped || !is_visible_in_tree() || !is_inside_tree())
 	{
 		frame_remainder = 0;
@@ -945,7 +946,8 @@ void godot::SpicyParticleSystemNode::set_max_particle_count(int p_max_particle_c
 	m_particle_system->set_max_particle_count(max_particles, rng);
 	m_renderer->resize_buffer();
 
-	stop();
+	if(is_inside_tree())
+		stop();
 }
 
 int godot::SpicyParticleSystemNode::get_max_particle_count() const

--- a/src/SpicyParticleSystemNode.cpp
+++ b/src/SpicyParticleSystemNode.cpp
@@ -565,6 +565,11 @@ bool godot::SpicyParticleSystemNode::get_looping() const
 void godot::SpicyParticleSystemNode::set_world_space(bool p_world_space)
 {
 	world_space = p_world_space;
+
+	if (world_space && is_inside_tree())
+		node_transform = get_global_transform();
+	else
+		node_transform = Transform3D();
 }
 
 bool godot::SpicyParticleSystemNode::get_world_space() const

--- a/src/SpicyParticleSystemNode.cpp
+++ b/src/SpicyParticleSystemNode.cpp
@@ -501,7 +501,7 @@ void godot::SpicyParticleSystemNode::set_duration(float p_duration)
 	duration = p_duration;
 	m_particle_system->final_data()->max_duration = duration;
 
-	_update_burst_times();
+	//_update_burst_times();
 }
 
 float godot::SpicyParticleSystemNode::get_duration() const
@@ -532,15 +532,15 @@ TypedArray<SpicyParticleBurst> godot::SpicyParticleSystemNode::get_emit_bursts()
 	return m_emit_bursts;
 }
 
-void godot::SpicyParticleSystemNode::_update_burst_times()
-{
-	for (int i = 0; i < m_emit_bursts.size(); ++i)
-	{
-		Ref<SpicyParticleBurst> burst = m_emit_bursts[i];
-		if (burst.is_valid())
-			burst->time = CLAMP(burst->time, 0, duration);
-	}
-}
+//void godot::SpicyParticleSystemNode::_update_burst_times()
+//{
+//	for (int i = 0; i < m_emit_bursts.size(); ++i)
+//	{
+//		Ref<SpicyParticleBurst> burst = m_emit_bursts[i];
+//		if (burst.is_valid())
+//			burst->time = CLAMP(burst->time, 0, duration);
+//	}
+//}
 
 void godot::SpicyParticleSystemNode::set_delay(float p_preprocess_time)
 {

--- a/src/SpicyParticleSystemNode.h
+++ b/src/SpicyParticleSystemNode.h
@@ -51,6 +51,7 @@ namespace godot
 		Ref<AccelerationUpdater> m_acceleration_updater;
 		Ref<RotationUpdater> m_rotation_updater;
 		Ref<SizeUpdater> m_size_updater;
+		Ref<CustomDataUpdater> m_custom_data_updater;
 
 		Ref<RandomNumberGenerator> rng;
 		uint64_t rng_state;
@@ -79,9 +80,9 @@ namespace godot
 		Ref<Mesh> mesh;
 		MultiMeshParticleRenderer::Alignment m_particle_alignment;
 		NodePath m_alignment_target;
+		bool use_custom_data;
 
 		Transform3D node_transform;
-		//bool m_custom_renderer_data = false;
 	protected:
 		static void _bind_methods();
 		void _validate_property(PropertyInfo& property) const;
@@ -184,7 +185,10 @@ namespace godot
 
 		//Scale updater
 		void set_size_updater(const Ref<SizeUpdater>& p_size_updater);
-		Ref<SizeUpdater> get_size_updater() const;
+		Ref<SizeUpdater> get_size_updater() const;		
+		
+		void set_custom_data_updater(const Ref<CustomDataUpdater>& p_custom_data_updater);
+		Ref<CustomDataUpdater> get_custom_data_updater() const;
 
 		// Render properties
 		void set_mesh(const Ref<Mesh>& p_mesh);
@@ -196,8 +200,8 @@ namespace godot
 		void set_alignment_target(const NodePath& p_path);
 		NodePath get_alignment_target() const;
 
-		//void set_custom_renderer_data(bool p_custom_renderer_data);
-		//bool get_custom_renderer_data() const;
+		void set_use_custom_data(bool p_use_custom_data);
+		bool get_use_custom_data() const;
 
 		void set_max_particle_count(int p_max_particle_count);
 		int get_max_particle_count() const;

--- a/src/SpicyParticleSystemNode.h
+++ b/src/SpicyParticleSystemNode.h
@@ -29,7 +29,7 @@ namespace godot
 	class SpicyParticleSystemNode : public GeometryInstance3D {
 		GDCLASS(SpicyParticleSystemNode, GeometryInstance3D)
 	private:
-		const float simulation_delta = 0.016667; //60fps
+		const double SIMULATION_DELTA = 0.016667; //60fps
 		bool initialized;
 		real_t max_particles;
 
@@ -74,7 +74,6 @@ namespace godot
 		real_t delay;
 		real_t simulation_speed;
 		double simulation_time;
-		double internal_process_time;
 		double normalized_duration_time;
 
 		Ref<Mesh> mesh;
@@ -87,7 +86,7 @@ namespace godot
 		static void _bind_methods();
 		void _validate_property(PropertyInfo& property) const;
 		void _update_null_properties();
-		void _update_burst_times();
+		//void _update_burst_times();
 		void _notification(int p_what);
 		void _stop_no_signal();
 	public:
@@ -98,8 +97,7 @@ namespace godot
 
 		void initialize(size_t max_count);
 		void emit_burst(int count);
-		void seek(double sim_time);
-		void step(double delta);
+		void seek(double t);
 
 		void pause(bool include_children = true);
 		void play(bool include_children = true);

--- a/src/SpicyParticleSystemNode.h
+++ b/src/SpicyParticleSystemNode.h
@@ -32,6 +32,7 @@ namespace godot
 		const double SIMULATION_DELTA = 0.016667; //60fps
 		bool initialized;
 		real_t max_particles;
+		bool _render = true;
 
 		//Particle system
 		Ref<SpicyParticleSystem> m_particle_system;
@@ -94,10 +95,11 @@ namespace godot
 		virtual ~SpicyParticleSystemNode();
 		PackedStringArray _get_configuration_warnings() const;
 		void _internal_process(double delta);
+		void _set_render(bool p_render, bool include_children = true);
 
 		void initialize(size_t max_count);
 		void emit_burst(int count);
-		void seek(double t);
+		void seek(double t, bool include_children = true);
 
 		void pause(bool include_children = true);
 		void play(bool include_children = true);

--- a/src/SpicyParticleSystemPlugin.cpp
+++ b/src/SpicyParticleSystemPlugin.cpp
@@ -15,6 +15,7 @@
 #include <godot_cpp/variant/callable_method_pointer.hpp>
 #include <godot_cpp/classes/resource_loader.hpp>
 #include <godot_cpp/classes/editor_interface.hpp>
+#include <godot_cpp/classes/editor_selection.hpp>
 #include <godot_cpp/variant/rect2.hpp>
 
 #include <godot_cpp/classes/time.hpp>
@@ -102,15 +103,6 @@ bool godot::SpicyParticleSystemInspectorPlugin::_parse_property(Object* object, 
 {
 	if (name == "seed")
 	{
-		//Button* button = memnew(Button);
-		////button->set_text("Randomize");
-		//button->set_theme_type_variation("InspectorActionButton");
-		//button->set_h_size_flags(Control::SizeFlags::SIZE_SHRINK_END);
-		//button->set_button_icon(base_ref->get_theme_icon("RandomNumberGenerator", "EditorIcons"));
-		//add_custom_control(button);
-
-		//seed = Time::get_singleton()->get_ticks_msec() + get_name().to_int();
-
 		EditorPropertyRandomInteger* editor = memnew(EditorPropertyRandomInteger);
 		editor->set_base_ref(base_ref);
 		editor->setup(0, 9999999, 1, false, false, false, "");
@@ -119,23 +111,28 @@ bool godot::SpicyParticleSystemInspectorPlugin::_parse_property(Object* object, 
 
 		return true;
 	}
+
+	//if (name == "simulation_time")
+	//{
+	//	return true;
+	//}
 	return false;
 }
 
-void godot::SpicyParticleSystemInspectorPlugin::_parse_group(Object* object, const String& group)
-{
-	//if (group == "Generators")
-	//{
-	//	//Could be used instead of having the empty resource slots
-	//	Button* button = memnew(Button);
-	//	button->set_text("Add Generator");
-	//	button->set_theme_type_variation("InspectorActionButton");
-	//	button->set_h_size_flags(Control::SizeFlags::SIZE_SHRINK_CENTER);
-	//	button->set_button_icon(base_ref->get_theme_icon("Add", "EditorIcons"));
-	//	add_custom_control(button);
-	//	//button->connect(SNAME("pressed"), callable_mp(this, &EditorInspector::_show_add_meta_dialog));
-	//}
-}
+//void godot::SpicyParticleSystemInspectorPlugin::_parse_group(Object* object, const String& group)
+//{
+//	//if (group == "Generators")
+//	//{
+//	//	//Could be used instead of having the empty resource slots
+//	//	Button* button = memnew(Button);
+//	//	button->set_text("Add Generator");
+//	//	button->set_theme_type_variation("InspectorActionButton");
+//	//	button->set_h_size_flags(Control::SizeFlags::SIZE_SHRINK_CENTER);
+//	//	button->set_button_icon(base_ref->get_theme_icon("Add", "EditorIcons"));
+//	//	add_custom_control(button);
+//	//	//button->connect(SNAME("pressed"), callable_mp(this, &EditorInspector::_show_add_meta_dialog));
+//	//}
+//}
 
 
 ////////////////////////////////////////////////////////////////////////
@@ -230,45 +227,106 @@ void godot::SpicyParticleSystemPlugin::set_play_icon()
 
 void godot::SpicyParticleSystemPlugin::_play_pause()
 {
-	if (system_node != nullptr) {
+	//if (system_node != nullptr) {
+	//	if (system_node->get_is_playing())
+	//	{
+	//		set_play_icon();
+	//		system_node->pause(only_selected);
+	//	}
+	//	else
+	//	{
+	//		set_pause_icon();
+	//		system_node->play(only_selected);
+	//	}
+	//}
+
+	for (int i = 0; i < selection.size(); i++)
+	{
+		SpicyParticleSystemNode* node = Object::cast_to<SpicyParticleSystemNode>(selection[i]);
+		if (node != nullptr)
+		{
+			if (node->get_is_playing())
+			{
+				node->pause();
+			}
+			else
+			{
+				node->play();
+			}
+		}
+	}
+
+	if (system_node != nullptr) 
+	{
 		if (system_node->get_is_playing())
 		{
 			set_play_icon();
-			system_node->pause(only_selected);
 		}
 		else
 		{
 			set_pause_icon();
-			system_node->play(only_selected);
 		}
 	}
 }
 
 void godot::SpicyParticleSystemPlugin::_restart()
 {
-	if (system_node != nullptr)
+	//if (system_node != nullptr)
+	//{
+	//	set_pause_icon();
+	//	system_node->restart(only_selected);
+	//}
+
+	for (int i = 0; i < selection.size(); i++)
 	{
-		set_pause_icon();
-		system_node->restart(only_selected);
+		SpicyParticleSystemNode* node = Object::cast_to<SpicyParticleSystemNode>(selection[i]);
+		if (node != nullptr)
+		{
+			node->restart();
+		}
 	}
+
+	set_play_icon();
 }
 
 void godot::SpicyParticleSystemPlugin::_stop()
 {
-	if (system_node != nullptr)
+	//if (system_node != nullptr)
+	//{
+	//	set_play_icon();
+	//	system_node->stop(only_selected);
+	//}
+
+	for (int i = 0; i < selection.size(); i++)
 	{
-		set_play_icon();
-		system_node->stop(only_selected);
+		SpicyParticleSystemNode* node = Object::cast_to<SpicyParticleSystemNode>(selection[i]);
+		if (node != nullptr)
+		{
+			node->stop();
+		}
 	}
+
+	set_play_icon();
 }
 
 void godot::SpicyParticleSystemPlugin::_set_simulation_time(double time)
 {
-	if (system_node != nullptr)
+	//if (system_node != nullptr)
+	//{
+	//	system_node->set_simulation_time(time);
+	//	set_play_icon();
+	//}
+
+	for (int i = 0; i < selection.size(); i++)
 	{
-		system_node->set_simulation_time(time);
-		set_play_icon();
+		SpicyParticleSystemNode* node = Object::cast_to<SpicyParticleSystemNode>(selection[i]);
+		if (node != nullptr)
+		{
+			node->seek(time, true);
+		}
 	}
+
+	set_play_icon();
 }
 
 void godot::SpicyParticleSystemPlugin::_move_button_up()
@@ -278,7 +336,44 @@ void godot::SpicyParticleSystemPlugin::_move_button_up()
 
 void godot::SpicyParticleSystemPlugin::_set_only_selected(bool show)
 {
-	only_selected = !show;
+	only_selected = show;
+
+	_update_selection();
+}
+
+void godot::SpicyParticleSystemPlugin::_update_selection()
+{
+	for (int i = 0; i < selection.size(); i++)
+	{
+		SpicyParticleSystemNode* node = Object::cast_to<SpicyParticleSystemNode>(selection[i]);
+		if (node != nullptr)
+		{
+			node->_set_render(true);
+		}
+	}
+
+	selection = get_editor_interface()->get_selection()->get_selected_nodes();
+
+	if (!only_selected)
+		return;
+
+	for (int i = 0; i < selection.size(); i++)
+	{
+		SpicyParticleSystemNode* node = Object::cast_to<SpicyParticleSystemNode>(selection[i]);
+		if (node != nullptr)
+		{
+			node->_set_render(false);
+		}
+	}
+
+	for (int i = 0; i < selection.size(); i++)
+	{
+		SpicyParticleSystemNode* node = Object::cast_to<SpicyParticleSystemNode>(selection[i]);
+		if (node != nullptr)
+		{
+			node->_set_render(true, false);
+		}
+	}
 }
 
 void godot::SpicyParticleSystemPlugin::_move_button_down()
@@ -351,6 +446,8 @@ void godot::SpicyParticleSystemPlugin::_create_on_screen_editor()
 	restart_icon = base_control->get_theme_icon("Reload", "EditorIcons");
 	stop_icon = base_control->get_theme_icon("Stop", "EditorIcons");
 
+	get_editor_interface()->get_selection()->connect("selection_changed", callable_mp(this, &SpicyParticleSystemPlugin::_update_selection));
+
 	on_screen_editor = memnew(PanelContainer);
 	on_screen_editor->set_name("spicy_particle_ose");
 	on_screen_editor->set_custom_minimum_size(Vector2(220, 140));
@@ -376,7 +473,7 @@ void godot::SpicyParticleSystemPlugin::_create_on_screen_editor()
 	vbox_parent.add_child(button_move);
 
 	CheckButton button_only_selected = CheckButton();
-	button_only_selected.set_text("Only selected");
+	button_only_selected.set_text("Selected only");
 	button_only_selected.set_toggle_mode(true);
 	button_only_selected.connect("toggled", callable_mp(this, &SpicyParticleSystemPlugin::_set_only_selected));
 	vbox_parent.add_child(&button_only_selected);
@@ -456,6 +553,41 @@ void godot::SpicyParticleSystemPlugin::_update_on_screen_editor()
 {
 	spin_box_time->set_value_no_signal(system_node->get_simulation_time());
 	label_count->set_text(String::num_int64(system_node->get_particle_count()));
+
+	//get all alive count from hierarchy
+
+	//int count = 0;
+
+	//SpicyParticleSystemNode* node = Object::cast_to<SpicyParticleSystemNode>(system_node->get_parent());
+	//bool found = false;
+	//if (node != nullptr) {
+	//	while (!found)
+	//	{
+	//		SpicyParticleSystemNode* temp = Object::cast_to<SpicyParticleSystemNode>(node->get_parent());
+
+	//		if (temp == nullptr)
+	//		{
+	//			found = true;
+	//		}
+	//		node = temp;
+	//	}
+	//}
+	//else
+	//{
+	//	node = system_node;
+	//}
+
+
+
+	//TypedArray<SpicyParticleSystemNode> children = node->find_children("*", SpicyParticleSystemNode::get_class_static(), true, false);
+	//for (int i = 0; i < children.size(); ++i)
+	//{
+	//	SpicyParticleSystemNode* child = cast_to<SpicyParticleSystemNode>(children[i]);
+	//	count += child->get_particle_count();
+	//}
+
+
+	//label_count->set_text(String::num_int64(count));
 }
 
 void godot::SpicyParticleSystemPlugin::_edit(Object* object)
@@ -490,6 +622,17 @@ void godot::SpicyParticleSystemPlugin::_edit(Object* object)
 		{
 			system_node->connect("stop", callable_mp(this, &SpicyParticleSystemPlugin::set_play_icon));
 		}
+
+
+		if (system_node->get_is_playing())
+		{
+			set_pause_icon();
+		}
+		else
+		{
+			set_play_icon();
+		}
+
 	}
 }
 

--- a/src/SpicyParticleSystemPlugin.cpp
+++ b/src/SpicyParticleSystemPlugin.cpp
@@ -51,6 +51,10 @@ void godot::SpicyParticleSystemModuleInspectorPlugin::_control_ref_added(Control
 				{
 					prop->set_self_modulate(base_ref->get_theme_color("property_color_z", "Editor"));
 				}
+				if (prop->get_edited_property().ends_with("_w"))
+				{
+					prop->set_self_modulate(base_ref->get_theme_color("property_color_w", "Editor"));
+				}
 			}
 		}
 	}

--- a/src/SpicyParticleSystemPlugin.cpp
+++ b/src/SpicyParticleSystemPlugin.cpp
@@ -109,7 +109,7 @@ bool godot::SpicyParticleSystemInspectorPlugin::_parse_property(Object* object, 
 
 		EditorPropertyRandomInteger* editor = memnew(EditorPropertyRandomInteger);
 		editor->set_base_ref(base_ref);
-		editor->setup(0, 999999, 1, false, false, false, "");
+		editor->setup(0, 9999999, 1, false, false, false, "");
 
 		add_property_editor(name, editor);
 
@@ -139,7 +139,7 @@ void godot::SpicyParticleSystemInspectorPlugin::_parse_group(Object* object, con
 
 void godot::EditorPropertyRandomInteger::_randomize_integer()
 {
-	int64_t seed = UtilityFunctions::randi_range(0, 999999);
+	int64_t seed = UtilityFunctions::randi_range(0, 9999999);
 
 	emit_changed(get_edited_property(), seed);
 }

--- a/src/SpicyParticleSystemPlugin.hpp
+++ b/src/SpicyParticleSystemPlugin.hpp
@@ -51,7 +51,7 @@ namespace godot
 
 		virtual bool _can_handle(Object* p_object) const;
 		virtual bool _parse_property(Object* object, Variant::Type type, const String& name, PropertyHint hint_type, const String& hint_string, BitField<PropertyUsageFlags> usage_flags, bool wide);
-		virtual void _parse_group(Object* object, const String& group);
+		//virtual void _parse_group(Object* object, const String& group);
 
 		inline void set_base_ref(const Control* control) { base_ref = control; }
 	};
@@ -103,7 +103,8 @@ namespace godot
 		Ref<Texture2D> restart_icon;
 		Ref<Texture2D> stop_icon;
 
-		bool only_selected = true;
+		bool only_selected = false;
+		TypedArray<Node> selection;
 
 		bool move_button_down = false;
 		Vector2 mouse_offset = Vector2(0, 0);
@@ -119,6 +120,7 @@ namespace godot
 		void _move_button_down();
 		void _move_button_up();
 		void _set_only_selected(bool show);
+		void _update_selection();
 	protected:
 		static void _bind_methods() {}
 	public:

--- a/src/SpicyParticleSystemPlugin.hpp
+++ b/src/SpicyParticleSystemPlugin.hpp
@@ -20,20 +20,63 @@
 
 namespace godot
 {
-	class SpicyParticleSystemInspectorPlugin : public EditorInspectorPlugin
+	class SpicyParticleSystemModuleInspectorPlugin : public EditorInspectorPlugin
 	{
-		GDCLASS(SpicyParticleSystemInspectorPlugin, EditorInspectorPlugin)
+		GDCLASS(SpicyParticleSystemModuleInspectorPlugin, EditorInspectorPlugin)
 	private:
 		const Control* base_ref = nullptr;
 	protected:
 		void _control_ref_added(Control* ref);
 		static void _bind_methods() {}
 	public:
+		SpicyParticleSystemModuleInspectorPlugin();
+		~SpicyParticleSystemModuleInspectorPlugin();
+
+		virtual bool _can_handle(Object* p_object) const;
+		virtual void _parse_end(Object* object);
+
+		inline void set_base_ref(const Control* control) { base_ref = control; }
+	};
+
+	class SpicyParticleSystemInspectorPlugin : public EditorInspectorPlugin
+	{
+		GDCLASS(SpicyParticleSystemInspectorPlugin, EditorInspectorPlugin)
+	private:
+		const Control* base_ref = nullptr;
+	protected:
+		static void _bind_methods() {}
+	public:
 		SpicyParticleSystemInspectorPlugin();
 		~SpicyParticleSystemInspectorPlugin();
 
 		virtual bool _can_handle(Object* p_object) const;
-		virtual void _parse_end(Object* object);
+		virtual bool _parse_property(Object* object, Variant::Type type, const String& name, PropertyHint hint_type, const String& hint_string, BitField<PropertyUsageFlags> usage_flags, bool wide);
+		virtual void _parse_group(Object* object, const String& group);
+
+		inline void set_base_ref(const Control* control) { base_ref = control; }
+	};
+
+	class EditorPropertyRandomInteger : public EditorProperty 
+	{
+		GDCLASS(EditorPropertyRandomInteger, EditorProperty);
+	private:
+		EditorSpinSlider* spin = nullptr;
+		Button* button = nullptr;
+		bool setting = false;
+		const Control* base_ref = nullptr;
+
+
+	protected:
+		static void _bind_methods();
+
+	public:
+		EditorPropertyRandomInteger();
+
+		void _randomize_integer();
+		void _value_changed(int64_t p_val);
+		virtual void _set_read_only(bool p_read_only) override;
+		virtual void _update_property() override;
+		void setup(int64_t p_min, int64_t p_max, int64_t p_step, bool p_hide_slider, bool p_allow_greater, bool p_allow_lesser, const String& p_suffix = String());
 
 		inline void set_base_ref(const Control* control) { base_ref = control; }
 	};
@@ -46,6 +89,7 @@ namespace godot
 		GDCLASS(SpicyParticleSystemPlugin, EditorPlugin)
 	private:
 		SpicyParticleSystemNode* system_node = nullptr;
+		Ref<SpicyParticleSystemModuleInspectorPlugin> module_inspector_plugin;
 		Ref<SpicyParticleSystemInspectorPlugin> inspector_plugin;
 		PanelContainer* on_screen_editor = nullptr;
 

--- a/src/SpicyParticleUpdater.cpp
+++ b/src/SpicyParticleUpdater.cpp
@@ -559,6 +559,7 @@ void godot::SizeUpdater::set_size_property(const Ref<SpicyVector3Property>& p_si
 		size_prop->set_default_uniform(Vector3(1, 1, 1));
 		size_prop->set_default_type(SpicyVector3Property::SpicyVector3Type::SPICY_VECTOR_TYPE_CURVE);
 	}
+
 }
 
 Ref<SpicyVector3Property> godot::SizeUpdater::get_size_property() const
@@ -603,4 +604,270 @@ bool godot::SizeUpdater::_property_get_revert(const StringName& p_name, Variant&
 		return size_property->get_property_revert(p_name, r_property);
 	}
 	return false;
+}
+
+//////////////////////////////////////////////////////////////////////////
+
+void godot::CustomDataUpdater::_bind_methods()
+{
+	ClassDB::bind_method(D_METHOD("set_custom_data_property_x", "custom_data_property_x"), &CustomDataUpdater::set_custom_data_property_x);
+	ClassDB::bind_method(D_METHOD("get_custom_data_property_x"), &CustomDataUpdater::get_custom_data_property_x);
+	ClassDB::bind_method(D_METHOD("set_custom_data_property_y", "custom_data_property_y"), &CustomDataUpdater::set_custom_data_property_y);
+	ClassDB::bind_method(D_METHOD("get_custom_data_property_y"), &CustomDataUpdater::get_custom_data_property_y);
+	ClassDB::bind_method(D_METHOD("set_custom_data_property_z", "custom_data_property_z"), &CustomDataUpdater::set_custom_data_property_z);
+	ClassDB::bind_method(D_METHOD("get_custom_data_property_z"), &CustomDataUpdater::get_custom_data_property_z);
+	ClassDB::bind_method(D_METHOD("set_custom_data_property_w", "custom_data_property_w"), &CustomDataUpdater::set_custom_data_property_w);
+	ClassDB::bind_method(D_METHOD("get_custom_data_property_w"), &CustomDataUpdater::get_custom_data_property_w);
+	ClassDB::bind_method(D_METHOD("set_use_builtin_data", "use_builtin_data"), &CustomDataUpdater::set_use_builtin_data);
+	ClassDB::bind_method(D_METHOD("get_use_builtin_data"), &CustomDataUpdater::get_use_builtin_data);
+
+	//ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_builtin_data"), "set_use_builtin_data", "get_use_builtin_data");
+}
+
+godot::CustomDataUpdater::CustomDataUpdater() : use_builtin_data(true)
+{
+	Ref<SpicyFloatProperty> custom_data_x(memnew(SpicyFloatProperty));
+	custom_data_property_x = custom_data_x;
+	custom_data_x->set_available_types(SpicyFloatProperty::SpicyFloatType::SPICY_FLOAT_TYPE_UNIFORM | SpicyFloatProperty::SpicyFloatType::SPICY_FLOAT_TYPE_CURVE);
+	custom_data_x->set_property_name("custom_data_x");
+	custom_data_x->set_default_uniform(0);
+
+	Ref<SpicyFloatProperty> custom_data_y(memnew(SpicyFloatProperty));
+	custom_data_property_y = custom_data_y;
+	custom_data_y->set_available_types(SpicyFloatProperty::SpicyFloatType::SPICY_FLOAT_TYPE_UNIFORM | SpicyFloatProperty::SpicyFloatType::SPICY_FLOAT_TYPE_CURVE);
+	custom_data_y->set_property_name("custom_data_y");
+	custom_data_y->set_default_uniform(0);
+
+	Ref<SpicyFloatProperty> custom_data_z(memnew(SpicyFloatProperty));
+	custom_data_property_z = custom_data_z;
+	custom_data_z->set_available_types(SpicyFloatProperty::SpicyFloatType::SPICY_FLOAT_TYPE_UNIFORM | SpicyFloatProperty::SpicyFloatType::SPICY_FLOAT_TYPE_CURVE);
+	custom_data_z->set_property_name("custom_data_z");
+	custom_data_z->set_default_uniform(0);
+
+	Ref<SpicyFloatProperty> custom_data_w(memnew(SpicyFloatProperty));
+	custom_data_property_w = custom_data_w;
+	custom_data_w->set_available_types(SpicyFloatProperty::SpicyFloatType::SPICY_FLOAT_TYPE_UNIFORM | SpicyFloatProperty::SpicyFloatType::SPICY_FLOAT_TYPE_CURVE);
+	custom_data_w->set_property_name("custom_data_w");
+	custom_data_w->set_default_uniform(0);
+}
+
+void godot::CustomDataUpdater::update(double dt, const Ref<ParticleData> p_data)
+{
+	unsigned int endId = p_data->count_alive;
+
+	if (use_builtin_data)
+	{
+		for (size_t i = 0; i < endId; ++i)
+		{
+			p_data->custom_data[i].x = Math::deg_to_rad(p_data->rotation[i].z + p_data->current_rotation[i].z);
+			p_data->custom_data[i].y = p_data->normalized_lifetime[i];
+			p_data->custom_data[i].z = p_data->custom_data[i].y;
+			p_data->custom_data[i].w = 0;
+		}
+	}
+	else
+	{
+		if (custom_data_property_x.is_valid() && custom_data_property_y.is_valid() && custom_data_property_z.is_valid() && custom_data_property_w.is_valid())
+		{
+			for (size_t i = 0; i < endId; ++i)
+			{
+				p_data->custom_data[i].x = custom_data_property_x->get_value(p_data->rng, p_data->normalized_lifetime[i]);
+				p_data->custom_data[i].y = custom_data_property_y->get_value(p_data->rng, p_data->normalized_lifetime[i]);
+				p_data->custom_data[i].z = custom_data_property_z->get_value(p_data->rng, p_data->normalized_lifetime[i]);
+				p_data->custom_data[i].w = custom_data_property_w->get_value(p_data->rng, p_data->normalized_lifetime[i]);
+			}
+		}
+	}
+
+}
+
+void godot::CustomDataUpdater::set_custom_data_property_x(const Ref<SpicyFloatProperty>& p_custom_data_property_x)
+{
+	custom_data_property_x = p_custom_data_property_x;
+
+	if (custom_data_property_x.is_null()) {
+		Ref<SpicyFloatProperty> custom_data_x(memnew(SpicyFloatProperty));
+		custom_data_property_x = custom_data_x;
+		custom_data_x->set_available_types(SpicyFloatProperty::SpicyFloatType::SPICY_FLOAT_TYPE_UNIFORM | SpicyFloatProperty::SpicyFloatType::SPICY_FLOAT_TYPE_CURVE);
+		custom_data_x->set_property_name("custom_data_x");
+		custom_data_x->set_default_uniform(0);
+	}
+}
+
+Ref<SpicyFloatProperty> godot::CustomDataUpdater::get_custom_data_property_x() const
+{
+	return custom_data_property_x;
+}
+
+void godot::CustomDataUpdater::set_custom_data_property_y(const Ref<SpicyFloatProperty>& p_custom_data_property_y)
+{
+	custom_data_property_y = p_custom_data_property_y;
+
+	if (custom_data_property_y.is_null()) {
+		Ref<SpicyFloatProperty> custom_data_y(memnew(SpicyFloatProperty));
+		custom_data_property_y = custom_data_y;
+		custom_data_y->set_available_types(SpicyFloatProperty::SpicyFloatType::SPICY_FLOAT_TYPE_UNIFORM | SpicyFloatProperty::SpicyFloatType::SPICY_FLOAT_TYPE_CURVE);
+		custom_data_y->set_property_name("custom_data_y");
+		custom_data_y->set_default_uniform(0);
+	}
+}
+
+Ref<SpicyFloatProperty> godot::CustomDataUpdater::get_custom_data_property_y() const
+{
+	return custom_data_property_y;
+}
+
+void godot::CustomDataUpdater::set_custom_data_property_z(const Ref<SpicyFloatProperty>& p_custom_data_property_z)
+{
+	custom_data_property_z = p_custom_data_property_z;
+
+	if (custom_data_property_z.is_null()) {
+		Ref<SpicyFloatProperty> custom_data_z(memnew(SpicyFloatProperty));
+		custom_data_property_z = custom_data_z;
+		custom_data_z->set_available_types(SpicyFloatProperty::SpicyFloatType::SPICY_FLOAT_TYPE_UNIFORM | SpicyFloatProperty::SpicyFloatType::SPICY_FLOAT_TYPE_CURVE);
+		custom_data_z->set_property_name("custom_data_z");
+		custom_data_z->set_default_uniform(0);
+	}
+}
+
+Ref<SpicyFloatProperty> godot::CustomDataUpdater::get_custom_data_property_z() const
+{
+	return custom_data_property_z;
+}
+
+void godot::CustomDataUpdater::set_custom_data_property_w(const Ref<SpicyFloatProperty>& p_custom_data_property_w)
+{
+	custom_data_property_w = p_custom_data_property_w;
+
+	if (custom_data_property_w.is_null()) {
+		Ref<SpicyFloatProperty> custom_data_w(memnew(SpicyFloatProperty));
+		custom_data_property_w = custom_data_w;
+		custom_data_w->set_available_types(SpicyFloatProperty::SpicyFloatType::SPICY_FLOAT_TYPE_UNIFORM | SpicyFloatProperty::SpicyFloatType::SPICY_FLOAT_TYPE_CURVE);
+		custom_data_w->set_property_name("custom_data_w");
+		custom_data_w->set_default_uniform(0);
+	}
+}
+
+Ref<SpicyFloatProperty> godot::CustomDataUpdater::get_custom_data_property_w() const
+{
+	return custom_data_property_w;
+}
+
+void godot::CustomDataUpdater::set_use_builtin_data(bool p_use_builtin_data)
+{
+	use_builtin_data = p_use_builtin_data;
+
+	notify_property_list_changed();
+}
+
+bool godot::CustomDataUpdater::get_use_builtin_data() const
+{
+	return use_builtin_data;
+}
+
+void godot::CustomDataUpdater::_get_property_list(List<PropertyInfo>* r_props) const
+{
+	if (use_builtin_data)
+		return;
+
+	if (custom_data_property_x.is_valid()) {
+		custom_data_property_x->get_property_list(r_props);
+	}
+	if (custom_data_property_y.is_valid()) {
+		custom_data_property_y->get_property_list(r_props);
+	}
+	if (custom_data_property_z.is_valid()) {
+		custom_data_property_z->get_property_list(r_props);
+	}
+	if (custom_data_property_w.is_valid()) {
+		custom_data_property_w->get_property_list(r_props);
+	}
+}
+
+bool godot::CustomDataUpdater::_get(const StringName& p_property, Variant& r_value) const
+{
+	if (use_builtin_data)
+		return false;
+
+	bool result = false;
+
+	if (custom_data_property_x.is_valid()) {
+		result = result || custom_data_property_x->get_property(p_property, r_value);
+	}
+	if (custom_data_property_y.is_valid()) {
+		result = result || custom_data_property_y->get_property(p_property, r_value);
+	}
+	if (custom_data_property_z.is_valid()) {
+		result = result || custom_data_property_z->get_property(p_property, r_value);
+	}
+	if (custom_data_property_w.is_valid()) {
+		result = result || custom_data_property_w->get_property(p_property, r_value);
+	}
+	return result;
+}
+
+bool godot::CustomDataUpdater::_set(const StringName& p_property, const Variant& p_value)
+{
+	if (use_builtin_data)
+		return false;
+
+	bool result = false;
+
+	if (custom_data_property_x.is_valid()) {
+		result = result || custom_data_property_x->set_property(p_property, p_value, Ref<Resource>(this));
+	}
+	if (custom_data_property_y.is_valid()) {
+		result = result || custom_data_property_y->set_property(p_property, p_value, Ref<Resource>(this));
+	}
+	if (custom_data_property_z.is_valid()) {
+		result = result || custom_data_property_z->set_property(p_property, p_value, Ref<Resource>(this));
+	}
+	if (custom_data_property_w.is_valid()) {
+		result = result || custom_data_property_w->set_property(p_property, p_value, Ref<Resource>(this));
+	}
+	return result;
+}
+
+bool godot::CustomDataUpdater::_property_can_revert(const StringName& p_name) const
+{
+	if (use_builtin_data)
+		return false;
+
+	bool result = false;
+
+	if (custom_data_property_x.is_valid()) {
+		result = result || custom_data_property_x->can_property_revert(p_name);
+	}
+	if (custom_data_property_y.is_valid()) {
+		result = result || custom_data_property_y->can_property_revert(p_name);
+	}
+	if (custom_data_property_z.is_valid()) {
+		result = result || custom_data_property_z->can_property_revert(p_name);
+	}
+	if (custom_data_property_w.is_valid()) {
+		result = result || custom_data_property_w->can_property_revert(p_name);
+	}
+	return result;
+}
+
+bool godot::CustomDataUpdater::_property_get_revert(const StringName& p_name, Variant& r_property) const
+{
+	if (use_builtin_data)
+		return false;
+
+	bool result = false;
+
+	if (custom_data_property_x.is_valid()) {
+		result = result || custom_data_property_x->get_property_revert(p_name, r_property);
+	}
+	if (custom_data_property_y.is_valid()) {
+		result = result || custom_data_property_y->get_property_revert(p_name, r_property);
+	}
+	if (custom_data_property_z.is_valid()) {
+		result = result || custom_data_property_z->get_property_revert(p_name, r_property);
+	}
+	if (custom_data_property_w.is_valid()) {
+		result = result || custom_data_property_w->get_property_revert(p_name, r_property);
+	}
+	return result;
 }

--- a/src/SpicyParticleUpdater.hpp
+++ b/src/SpicyParticleUpdater.hpp
@@ -166,6 +166,45 @@ namespace godot
 		bool _property_get_revert(const StringName& p_name, Variant& r_property) const;
 	};
 
+	class CustomDataUpdater : public SpicyParticleUpdater {
+		GDCLASS(CustomDataUpdater, SpicyParticleUpdater);
+	public:
+		Ref<SpicyFloatProperty> custom_data_property_x; //can be built-int or custom //lifetime
+		Ref<SpicyFloatProperty> custom_data_property_y; //can be built-int or custom //loop phase (duration/lifetime)
+		Ref<SpicyFloatProperty> custom_data_property_z; //can be built-int or custom //offset
+		Ref<SpicyFloatProperty> custom_data_property_w; //can be custom
+
+		bool use_builtin_data;
+	protected:
+		static void _bind_methods();
+	public:
+		CustomDataUpdater();
+		virtual ~CustomDataUpdater() {}
+
+		virtual void update(double dt, const Ref<ParticleData> p_data) override;
+
+		void set_custom_data_property_x(const Ref<SpicyFloatProperty>& p_custom_data_property_x);
+		Ref<SpicyFloatProperty> get_custom_data_property_x() const;
+
+		void set_custom_data_property_y(const Ref<SpicyFloatProperty>& p_custom_data_property_y);
+		Ref<SpicyFloatProperty> get_custom_data_property_y() const;
+
+		void set_custom_data_property_z(const Ref<SpicyFloatProperty>& p_custom_data_property_z);
+		Ref<SpicyFloatProperty> get_custom_data_property_z() const;
+
+		void set_custom_data_property_w(const Ref<SpicyFloatProperty>& p_custom_data_property_w);
+		Ref<SpicyFloatProperty> get_custom_data_property_w() const;
+
+		void set_use_builtin_data(bool p_use_builtin_data);
+		bool get_use_builtin_data() const;
+
+		void _get_property_list(List<PropertyInfo>* r_props) const;
+		bool _get(const StringName& p_property, Variant& r_value) const;
+		bool _set(const StringName& p_property, const Variant& p_value);
+		bool _property_can_revert(const StringName& p_name) const;
+		bool _property_get_revert(const StringName& p_name, Variant& r_property) const;
+	};
+
 }
 
 

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -50,7 +50,9 @@ void initialize_spicyparticlesystem_module(ModuleInitializationLevel p_level) {
 	}
 
 	if (p_level == MODULE_INITIALIZATION_LEVEL_EDITOR) {
+		ClassDB::register_class<SpicyParticleSystemModuleInspectorPlugin>();
 		ClassDB::register_class<SpicyParticleSystemInspectorPlugin>();
+		ClassDB::register_class<EditorPropertyRandomInteger>();
 		ClassDB::register_class<SpicyParticleSystemPlugin>();
 		EditorPlugins::add_by_type<SpicyParticleSystemPlugin>();
 	}

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -35,6 +35,7 @@ void initialize_spicyparticlesystem_module(ModuleInitializationLevel p_level) {
 		ClassDB::register_class<AccelerationUpdater>();
 		ClassDB::register_class<RotationUpdater>();
 		ClassDB::register_class<SizeUpdater>();
+		ClassDB::register_class<CustomDataUpdater>();
 
 		ClassDB::register_class<SpicyFloatProperty>();
 		ClassDB::register_class<SpicyVector3Property>();


### PR DESCRIPTION
Changes:
- Add randomize button to the seed property
- Add custom particle data updater (and support for built-in particle shader features)
- Update stored transform when world_space is toggled
- Stopped modifying burst times when changing system duration
- Added vector W component colours
- On screen editor improvements
     - When "Selected only" toggled, only selected nodes are rendered, but all in system-hierarchy are simulated
     - Multi-select controls improved
- Seeking:
     - Optimizations
     - System hierarchy seeking
     - On screen editor seeking improved
Fixes:
- Fix for when get_global_transform gets called too early
- Fix for an error when duplicating systems
- Fix for alignment nodes not being affected by scale
- Fix for incorrect velocity alignment